### PR TITLE
ANA-25: Add column sorting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,7 +56,6 @@
         "no-extra-bind": ["error"],
         "no-extra-boolean-cast": ["error"],
         "no-inline-comments": ["error"],
-        "no-implicit-coercion": ["error"],
         "no-implied-eval": ["error"],
         "no-inner-declarations": ["off"],
         "no-invalid-this": ["error"],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,8 @@
 {
     "singleQuote": true,
     "printWidth": 80,
-    "editor.formatOnSave": true,
     "proseWrap": "always",
     "tabWidth": 4,
-    "requireConfig": false,
     "useTabs": false,
     "trailingComma": "none",
     "bracketSpacing": true,

--- a/examples/App.jsx
+++ b/examples/App.jsx
@@ -24,6 +24,7 @@ class PivotTableUISmartWrapper extends React.PureComponent {
     render() {
         return (
             <PivotTableUI
+                enableColumnSorting
                 renderers={Object.assign(
                     {},
                     TableRenderers,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@m3ter-com/react-pivottable",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "description": "A M3ter fork of plotly's react-pivottable",
     "main": "PivotTableUI.js",
     "files": [

--- a/src/PivotTableUI.jsx
+++ b/src/PivotTableUI.jsx
@@ -378,7 +378,7 @@ class PivotTableUI extends React.PureComponent {
                     <DraggableAttribute
                         name={x}
                         key={x}
-                        attrValues={this.state.attrValues[x]}
+                        attrValues={this.state.attrValues[x] || {}}
                         valueFilter={this.props.valueFilter[x] || {}}
                         sorter={getSort(this.props.sorters, x)}
                         menuLimit={this.props.menuLimit}
@@ -617,6 +617,7 @@ class PivotTableUI extends React.PureComponent {
 }
 
 PivotTableUI.propTypes = Object.assign({}, PivotTable.propTypes, {
+    enableColumnSorting: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     hiddenAttributes: PropTypes.arrayOf(PropTypes.string),
     hiddenFromAggregators: PropTypes.arrayOf(PropTypes.string),
@@ -626,6 +627,7 @@ PivotTableUI.propTypes = Object.assign({}, PivotTable.propTypes, {
 });
 
 PivotTableUI.defaultProps = Object.assign({}, PivotTable.defaultProps, {
+    enableColumnSorting: false,
     hiddenAttributes: [],
     hiddenFromAggregators: [],
     hiddenFromDragDrop: [],

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -12,6 +12,11 @@ import PropTypes from 'prop-types';
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 
+const ASCENDING_SORT_LABEL = 'asc';
+const DESCENDING_SORT_LABEL = 'desc';
+const ROW_COL_KEY_JOINER = String.fromCharCode(0);
+const FALLBACK_ROW_VALUE = {value: () => null};
+
 const addSeparators = function(nStr, thousandsSep, decimalSep) {
   const x = String(nStr).split('.');
   let x1 = x[0];
@@ -611,6 +616,40 @@ class PivotData {
     };
   }
 
+  getUserSortedRowKeys(columnKey, sortOrder) {
+    try {
+      const {rowKeys, tree} = this;
+      const sortMultiplier = sortOrder === ASCENDING_SORT_LABEL ? 1 : -1;
+
+      // This rowKeys array is structured in a strange way.
+      // If, for example, we have three row headers added to the pivot table
+      // and these are Region, Age and Gender, rowKeys might look something like:
+      /**
+       * [
+       *     ['UK', 21, 'Male'],
+       *     ['UK', 21, 'Female'],
+       *     ...
+       * ]
+       */
+      // So, to get the value of a specific row on a specific column (so that we can
+      // sort the rows), we need to use this.tree, which stores all the table data
+      // using keys made up of these inner rowKeys arrays joined by a specific character
+      // (ROW_COL_JOINER).
+      return [...rowKeys].sort((rowAKeySet, rowBKeySet) => {
+        const rowAKey = rowAKeySet.join(ROW_COL_KEY_JOINER);
+        const rowAValue = tree[rowAKey][columnKey] || FALLBACK_ROW_VALUE;
+        const rowBKey = rowBKeySet.join(ROW_COL_KEY_JOINER);
+        const rowBValue = tree[rowBKey][columnKey] || FALLBACK_ROW_VALUE;
+
+        return (
+          sortMultiplier * naturalSort(rowAValue.value(), rowBValue.value())
+        );
+      });
+    } catch (e) {
+      return this.rowKeys;
+    }
+  }
+
   sortKeys() {
     if (!this.sorted) {
       this.sorted = true;
@@ -658,8 +697,8 @@ class PivotData {
     for (const x of Array.from(this.props.rows)) {
       rowKey.push(x in record ? record[x] : 'null');
     }
-    const flatRowKey = rowKey.join(String.fromCharCode(0));
-    const flatColKey = colKey.join(String.fromCharCode(0));
+    const flatRowKey = rowKey.join(ROW_COL_KEY_JOINER);
+    const flatColKey = colKey.join(ROW_COL_KEY_JOINER);
 
     this.allTotal.push(record);
 
@@ -696,8 +735,8 @@ class PivotData {
 
   getAggregator(rowKey, colKey) {
     let agg;
-    const flatRowKey = rowKey.join(String.fromCharCode(0));
-    const flatColKey = colKey.join(String.fromCharCode(0));
+    const flatRowKey = rowKey.join(ROW_COL_KEY_JOINER);
+    const flatColKey = colKey.join(ROW_COL_KEY_JOINER);
     if (rowKey.length === 0 && colKey.length === 0) {
       agg = this.allTotal;
     } else if (rowKey.length === 0) {
@@ -812,4 +851,7 @@ export {
   getSort,
   sortAs,
   PivotData,
+  ASCENDING_SORT_LABEL,
+  DESCENDING_SORT_LABEL,
+  ROW_COL_KEY_JOINER,
 };

--- a/src/pivottable.css
+++ b/src/pivottable.css
@@ -34,6 +34,12 @@ table.pvtTable tbody tr th {
 table.pvtTable .pvtColLabel {
     text-align: center;
 }
+table.pvtTable .pvtColLabelInner {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    align-items: center;
+}
 table.pvtTable .pvtTotalLabel {
     text-align: right;
 }
@@ -320,4 +326,26 @@ table.pvtTable tbody tr td {
 
 .pvtRendererArea {
     padding: 5px;
+}
+
+.pvtColSortButtonsWrapper {
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: center;
+    margin-left: 5px;
+}
+
+.pvtColSortButton {
+    padding: 0 5px;
+    margin-left: 5px;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    color: #506784;
+}
+
+.pvtColSortButton-active,
+.pvtColSortButton:hover {
+    color: #119dff;
 }


### PR DESCRIPTION
Add column sorting functionality to the pivot table.

Enable source maps on webpack-dev-server for local debugging.

Fix react proptypes error due to the `attrValues` prop being passed to
`DraggableAttribute` being possibly undefined.