### PR TITLE
CON-94: Add declaration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,15 +2,4 @@ node_modules
 npm-debug.log
 examples/bundle.js
 
-/PivotTable.js
-/PivotTable.js.map
-/PivotTableUI.js
-/PivotTableUI.js.map
-/PlotlyRenderers.js
-/PlotlyRenderers.js.map
-/TableRenderers.js
-/TableRenderers.js.map
-/Utilities.js
-/Utilities.js.map
-/__tests__/*
-/pivottable.css
+dist

--- a/package.json
+++ b/package.json
@@ -1,20 +1,11 @@
 {
     "name": "@m3ter-com/react-pivottable",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "description": "A M3ter fork of plotly's react-pivottable",
-    "main": "PivotTableUI.js",
+    "main": "dist/PivotTableUI.js",
+    "types": "dist/PivotTableUI.d.ts",
     "files": [
-        "PivotTable.js",
-        "PivotTableUI.js",
-        "PlotlyRenderers.js",
-        "TableRenderers.js",
-        "Utilities.js",
-        "PivotTable.js.map",
-        "PivotTableUI.js.map",
-        "PlotlyRenderers.js.map",
-        "TableRenderers.js.map",
-        "Utilities.js.map",
-        "pivottable.css"
+        "dist"
     ],
     "scripts": {
         "start": "webpack serve",
@@ -24,8 +15,8 @@
         "test:prettier:fix": "prettier  --write \"src/*.js*\"",
         "test:jest": "jest",
         "test": "yarn run test:eslint && yarn run test:prettier && yarn run test:jest",
-        "clean": "rm -rf __tests__ PivotTable.js* PivotTableUI.js* PlotlyRenderers.js* TableRenderers.js* Utilities.js* pivottable.css",
-        "build": "yarn run clean && cp src/pivottable.css . && babel src --out-dir=. --source-maps"
+        "clean": "rm -rf __tests__ dist",
+        "build": "yarn run clean && babel src/*.{js,jsx} --out-dir=./dist --source-maps && cp src/pivottable.css ./dist/pivottable.css && cp src/PivotTableUI.d.ts ./dist/PivotTableUI.d.ts"
     },
     "repository": {
         "type": "git",

--- a/src/PivotTableUI.d.ts
+++ b/src/PivotTableUI.d.ts
@@ -1,0 +1,28 @@
+type PivotTableUIProps = {
+    aggregatorName?: string;
+    aggregators?: Record<string, Function>;
+    colOrder?: string;
+    cols?: Array<string>;
+    derivedAttributes?: Record<string, Function>;
+    data: Array<Record<string, any>>;
+    enableColumnSorting?: boolean;
+    hiddenAttributes?: Array<string>;
+    hiddenFromAggregators?: Array<string>;
+    hiddenFromDragDrop?: Array<string>;
+    menuLimit?: number;
+    rendererName?: string;
+    renderers?: Record<string, Function>;
+    rowOrder?: string;
+    rows?: Array<string>;
+    sorters?: Record<string, Function>;
+    tableColorScaleGenerator?: Record<string, Function>;
+    tableOptions?: Record<string, any>;
+    unusedOrientationCutoff?: number;
+    valueFilter?: Record<string, Function>;
+    vals?: Array<string>;
+    onChange: (state: PivotTableUIProps) => void;
+    valueFormatter?: (cellValue?: number) => string;
+};
+
+declare const PivotTableUI: React.FC<PivotTableUIProps>;
+export default PivotTableUI;


### PR DESCRIPTION
Add a TypeScript declaration file so that we can consume this package in our typescript projects without having to provide our own typings. This will hopefully mean we are more likely to keep the types in sync with the JS and will mean we don't need to do workarounds to get the types for this package bundled into our other libraries.

Update the build script to build to a `dist` directory rather than the root so that we can use the `fields` option in package.json to include everything inside of `dist` instead of having to list all the relevant files individually.
Update this script to also copy the new declaration file into the build output.
Add the `types` field to `package.json` to make sure consumers can pick the types up.